### PR TITLE
Fix typo in discovery section

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ npm run deploy
 
 ### Discovery
 
-Currently, `.well-known/mcp` discovery is under active discussion ([see here](https://github.com/orgs/modelcontextprotocol/discussions/84)). For now, share your URL directl and provide instructions for users to connect.
+Currently, `.well-known/mcp` discovery is under active discussion ([see here](https://github.com/orgs/modelcontextprotocol/discussions/84)). For now, share your URL directly and provide instructions for users to connect.
 
 ## Using Your Me-MCP
 


### PR DESCRIPTION
## Summary
- fix a small typo in the README Discovery section

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_683f426b009c832a9cef83703290be70