### PR TITLE
Fix readme header comment

### DIFF
--- a/src/readme.ts
+++ b/src/readme.ts
@@ -1,9 +1,9 @@
 import { html } from 'hono/html'
 
 /**
- * This is a really simple HTML page using pico.css to provide some basic styling and
- * and uses document.write to dynamically insert the MCP URL.  This is just fine for
- * a simple page like this.
+ * This is a really simple HTML page using pico.css to provide some basic styling and uses
+ * document.write to dynamically insert the MCP URL.  This is just fine for a simple page
+ * like this.
  */
 export default function renderReadme(c, name: string) {
     return c.html(


### PR DESCRIPTION
## Summary
- fix a doubled word in the src/readme.ts header comment

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f426f5c38832ab8764ecba7ca3be2