### PR TITLE
Add vitest tests for contact-owner

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "dev": "wrangler dev",
     "start": "wrangler dev",
     "deploy": "wrangler deploy",
-    "cf-typegen": "wrangler types --env-interface CloudflareBindings"
+    "cf-typegen": "wrangler types --env-interface CloudflareBindings",
+    "test": "vitest"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",
@@ -17,6 +18,7 @@
     "@hono/vite-build": "^1.5.0",
     "vite": "^6.1.1",
     "vite-plugin-ssr-hot-reload": "^0.4.1",
-    "wrangler": "^4.4.0"
+    "wrangler": "^4.4.0",
+    "vitest": "^1.5.0"
   }
 }

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -1,0 +1,34 @@
+import { beforeAll, describe, it, expect } from "vitest";
+
+let contactOwner: any;
+
+beforeAll(async () => {
+  process.env.DISCORD_WEBHOOK_URL = "https://example.com";
+  process.env.MCP_OWNER_NAME = "Test";
+
+  const mod = await import("../tools");
+  const fakeServer = {
+    tool(name: string, desc: string, schema: any, handler: any) {
+      if (name === "contact-owner") {
+        contactOwner = handler;
+      }
+    },
+  } as any;
+
+  mod.default(fakeServer);
+});
+
+describe("contact-owner tool", () => {
+  it("returns an error when message exceeds 2000 characters", async () => {
+    const longMessage = "a".repeat(2001);
+    const result = await contactOwner({
+      name: "Tester",
+      email: "tester@example.com",
+      message: longMessage,
+    });
+
+    expect(result.content[0].text).toBe(
+      "Your message is too long. Please limit it to 2000 characters."
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add `vitest` as a dev dependency and provide a `test` script
- create tests for the `contact-owner` tool verifying the 2000 character limit

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f42c90568832abaf45bea0c6210ad